### PR TITLE
give an error when a crawled link gives an error status code

### DIFF
--- a/src/crawler.coffee
+++ b/src/crawler.coffee
@@ -26,8 +26,8 @@ createIt = (url) =>
     )
 
 exports.processResponse = (parent, res, templateValues, done) =>
-  return done(res.text) if not res.ok
-  return done("Not a valid response: #{res.text}") if not validate parent, res
+  return done("Bad status #{res.status} for url #{res.url}") if not res.ok
+  return done("Not a valid response: #{res.body}") if not validate parent, res
   describe "#{parent}", ->
     _.forEach exports.getLinks(res), (link) ->
       expandedLink = expandUrl(link, templateValues)

--- a/test/crawler.spec.coffee
+++ b/test/crawler.spec.coffee
@@ -32,6 +32,14 @@ describe 'Crawler with server', ->
       routeOne: 'route1'
       routeFour: 'route4'
 
+  err_config =
+    url: "http://localhost:#{PORT}/{routeOne}"
+    options:
+      headers:
+        Accept: 'application/json'
+    templateValues:
+      routeOne: 'error'
+
   before (done) ->
     stubbedDone = sinon.stub()
     stubbedIt = sinon.stub().callsArgWith 1, stubbedDone
@@ -53,6 +61,14 @@ describe 'Crawler with server', ->
       stubbedDone.alwaysCalledWith null
       done()
     ), 1000 # wait for all the calls to finish. Might be a better way to do it
+
+  it 'should give an error when a crawled link gives an error status code', (done) ->
+    crawler.startCrawl err_config, (url, cb) ->
+      cb (err) ->
+        if err
+          done()
+        else
+          done('Bad status response while crawling should trigger a failed test')
 
   describe "Additional validation", ->
     it 'should call validate function', (done) ->

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -35,12 +35,18 @@ exports.createServer = (port) ->
     _links:
       self: "http://localhost:#{port}/{routeFour}"
 
+  ERROR_RESPONSE =
+    error:
+      code: "OH_NO"
+      message: "Oh no!"
+
   server = http.createServer (req, res) ->
     switch req.url
       when '/route1' then send res, 200, server.LINKS_AT_ROOT
       when '/route2' then send res, 200, server.LINKS_IN_ARRAY
       when '/route3' then send res, 200, server.LINKS_IN_OBJECT
       when '/route4' then send res, 200, server.LINKS_WITH_TEMPLATE
+      when '/error'  then send res, 400, server.ERROR_RESPONSE
       else send res, 404, 'Not found'
 
   server.LINKS_AT_ROOT = LINKS_AT_ROOT


### PR DESCRIPTION
@TabDigital/api 

This will make the smoke tests fail when we bump the npm version until https://github.com/TabDigital/api-smoke-tests/pull/27 is merged.
