### PR TITLE
templateValues were leaking between tests due to scoping

### DIFF
--- a/src/crawler.coffee
+++ b/src/crawler.coffee
@@ -18,11 +18,11 @@ exports.setConfig = (userconfig) ->
 setIt = (it) ->
   localItFunction = it
 
-createIt = (url) =>
+createIt = (url, templateValues) =>
   localItFunction url, (done) =>
     build.request(url, config.options).end(
       (res) =>
-        exports.processResponse(url, res, config.templateValues, done)
+        exports.processResponse(url, res, templateValues, done)
     )
 
 exports.processResponse = (parent, res, templateValues, done) =>
@@ -30,9 +30,9 @@ exports.processResponse = (parent, res, templateValues, done) =>
   return done("Not a valid response: #{res.body}") if not validate parent, res
   describe "#{parent}", ->
     _.forEach exports.getLinks(res), (link) ->
+      linkFilter.processLink link
       expandedLink = expandUrl(link, templateValues)
-      linkFilter.processLink expandedLink
-      exports.crawl expandedLink
+      exports.crawl expandedLink, templateValues
   done()
 
 expandUrl = (url, values) ->
@@ -45,8 +45,8 @@ validate = (url, res) ->
   return true if not config?.validate?
   return config.validate(url, res.body)
 
-exports.crawl = (url) ->
-  createIt url
+exports.crawl = (url, templateValues) ->
+  createIt url, templateValues
 
 exports.startCrawl = (config, it) ->
   exports.reset()
@@ -54,7 +54,7 @@ exports.startCrawl = (config, it) ->
   exports.setConfig config
   expandedUrl = expandUrl(config.url, config.templateValues)
   linkFilter.processLink expandedUrl
-  exports.crawl expandedUrl
+  exports.crawl expandedUrl, config.templateValues
 
 exports.reset = ->
   linkFilter.reset()

--- a/test/crawler.spec.coffee
+++ b/test/crawler.spec.coffee
@@ -134,11 +134,11 @@ describe 'Crawler', ->
       crawler.processResponse 'parent', OK_RES, null, ->
 
       crawler.crawl.callCount.should.eql 5
-      assertCalledWith crawler.crawl, 0, ['a']
-      assertCalledWith crawler.crawl, 1, ['b']
-      assertCalledWith crawler.crawl, 2, ['c']
-      assertCalledWith crawler.crawl, 3, ['d']
-      assertCalledWith crawler.crawl, 4, ['e']
+      assertCalledWith crawler.crawl, 0, ['a', null]
+      assertCalledWith crawler.crawl, 1, ['b', null]
+      assertCalledWith crawler.crawl, 2, ['c', null]
+      assertCalledWith crawler.crawl, 3, ['d', null]
+      assertCalledWith crawler.crawl, 4, ['e', null]
 
     it 'should crawl specified percentage of links', ->
       crawler.setConfig {samplePercentage: 75}
@@ -154,5 +154,5 @@ describe 'Crawler', ->
       crawler.processResponse 'parent', OK_RES, {value1: 'one', value2: 'two'}, ->
 
       crawler.crawl.callCount.should.eql 2
-      assertCalledWith crawler.crawl, 0, ['/one?query=two']
-      assertCalledWith crawler.crawl, 1, ['b']
+      assertCalledWith crawler.crawl, 0, ['/one?query=two', {value1: 'one', value2: 'two'}]
+      assertCalledWith crawler.crawl, 1, ['b', {value1: 'one', value2: 'two'}]


### PR DESCRIPTION
@TabDigital/api 

This fixes a scoping issue with https://github.com/TabDigital/hyperactive/commit/fc82eff68c8a84b68c755c7811e4858f966b2f05 which was leaking templateValues between crawls.
