### PR TITLE
Crawls links in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lodash": "~2.4.1",
     "js-match": "~1.0.6",
     "unirest": "~0.2.7",
-    "uri-templates": "~0.1.5"
+    "uri-templates": "~0.1.5",
+    "async": "~0.9.0"
   }
 }

--- a/src/crawler.coffee
+++ b/src/crawler.coffee
@@ -1,4 +1,5 @@
 _           = require 'lodash'
+async       = require 'async'
 templates   = require 'uri-templates'
 linkFinder  = require './link_finder'
 linkFilter  = require './link_filter'
@@ -25,15 +26,31 @@ createIt = (url, templateValues) =>
         exports.processResponse(url, res, templateValues, done)
     )
 
+exports.createItWithResult = (url, err) ->
+  localItFunction url, (done) ->
+    done err
+
 exports.processResponse = (parent, res, templateValues, done) =>
   return done("Bad status #{res.status} for url #{res.url}") if not res.ok
-  return done("Not a valid response: #{res.body}") if not validate parent, res
+  try
+    if not validate parent, res
+      return done("Not a valid response: #{res.body}")
+  catch err
+    return done(err)
+
   describe "#{parent}", ->
-    _.forEach exports.getLinks(res), (link) ->
-      linkFilter.processLink link
-      expandedLink = expandUrl(link, templateValues)
-      exports.crawl expandedLink, templateValues
-  done()
+    requests = _.map exports.getLinks(res), (link) ->
+      (callback) ->
+        linkFilter.processLink link
+        expandedLink = expandUrl(link, templateValues)
+        build.request(expandedLink, config.options).end (res) =>
+          exports.processResponse expandedLink, res, templateValues, (err) ->
+            callback null, {err, link: expandedLink}
+
+    async.parallel requests, (err, results) ->
+      results.forEach (result) ->
+        exports.createItWithResult result.link, result.err
+      done()
 
 expandUrl = (url, values) ->
   if _.isObject(values) and not _.isEmpty(values)
@@ -45,16 +62,13 @@ validate = (url, res) ->
   return true if not config?.validate?
   return config.validate(url, res.body)
 
-exports.crawl = (url, templateValues) ->
-  createIt url, templateValues
-
 exports.startCrawl = (config, it) ->
   exports.reset()
   setIt it if it
   exports.setConfig config
   expandedUrl = expandUrl(config.url, config.templateValues)
   linkFilter.processLink expandedUrl
-  exports.crawl expandedUrl, config.templateValues
+  createIt expandedUrl, config.templateValues
 
 exports.reset = ->
   linkFilter.reset()

--- a/test/crawler.spec.coffee
+++ b/test/crawler.spec.coffee
@@ -53,10 +53,10 @@ describe 'Crawler with server', ->
     crawler.startCrawl config, stubbedIt
     setTimeout (->
       stubbedIt.callCount.should.eql 4
-      assertCalledWithFirstArg stubbedIt, 0, "http://localhost:#{PORT}/route1"
-      assertCalledWithFirstArg stubbedIt, 1, "http://localhost:#{PORT}/route2"
-      assertCalledWithFirstArg stubbedIt, 2, "http://localhost:#{PORT}/route4"
-      assertCalledWithFirstArg stubbedIt, 3, "http://localhost:#{PORT}/route3"
+      sinon.assert.calledWith stubbedIt, "http://localhost:#{PORT}/route1"
+      sinon.assert.calledWith stubbedIt, "http://localhost:#{PORT}/route2"
+      sinon.assert.calledWith stubbedIt, "http://localhost:#{PORT}/route4"
+      sinon.assert.calledWith stubbedIt, "http://localhost:#{PORT}/route3"
       stubbedDone.callCount.should.eql 4
       stubbedDone.alwaysCalledWith null
       done()
@@ -121,10 +121,11 @@ describe 'Crawler', ->
   describe 'processResponse', ->
 
     beforeEach ->
-      sinon.stub(crawler, 'crawl')
+      sinon.stub(crawler, 'createItWithResult')
+      crawler.setConfig options: {}
 
     afterEach ->
-      crawler.crawl.restore()
+      crawler.createItWithResult.restore()
 
     it 'should crawl links that have not previously been crawled', ->
       linkFinder.getLinks.onCall(0).returns ['a', 'b', 'c', 'b']
@@ -133,12 +134,12 @@ describe 'Crawler', ->
       crawler.processResponse 'parent', OK_RES, null, ->
       crawler.processResponse 'parent', OK_RES, null, ->
 
-      crawler.crawl.callCount.should.eql 5
-      assertCalledWith crawler.crawl, 0, ['a', null]
-      assertCalledWith crawler.crawl, 1, ['b', null]
-      assertCalledWith crawler.crawl, 2, ['c', null]
-      assertCalledWith crawler.crawl, 3, ['d', null]
-      assertCalledWith crawler.crawl, 4, ['e', null]
+      crawler.createItWithResult.callCount.should.eql 5
+      sinon.assert.calledWith crawler.createItWithResult, 'a'
+      sinon.assert.calledWith crawler.createItWithResult, 'b'
+      sinon.assert.calledWith crawler.createItWithResult, 'c'
+      sinon.assert.calledWith crawler.createItWithResult, 'd'
+      sinon.assert.calledWith crawler.createItWithResult, 'e'
 
     it 'should crawl specified percentage of links', ->
       crawler.setConfig {samplePercentage: 75}
@@ -146,13 +147,13 @@ describe 'Crawler', ->
 
       crawler.processResponse 'parent', OK_RES, null, ->
 
-      crawler.crawl.callCount.should.eql 3
+      crawler.createItWithResult.callCount.should.eql 3
 
     it 'should crawl links with uri template', ->
       linkFinder.getLinks.onCall(0).returns ['/{value1}?query={value2}{&value3}', 'b']
 
       crawler.processResponse 'parent', OK_RES, {value1: 'one', value2: 'two'}, ->
 
-      crawler.crawl.callCount.should.eql 2
-      assertCalledWith crawler.crawl, 0, ['/one?query=two', {value1: 'one', value2: 'two'}]
-      assertCalledWith crawler.crawl, 1, ['b', {value1: 'one', value2: 'two'}]
+      crawler.createItWithResult.callCount.should.eql 2
+      sinon.assert.calledWith crawler.createItWithResult, '/one?query=two'
+      sinon.assert.calledWith crawler.createItWithResult,  'b'


### PR DESCRIPTION
@TabDigital/api 

The links are now called in parallel, then an `it` is created with the result of the request

Benchmarking this has seen an improvement from 14m down to 2m
